### PR TITLE
Vectorize correlation computation

### DIFF
--- a/cpac_correlations.py
+++ b/cpac_correlations.py
@@ -15,8 +15,8 @@ import itertools
 Axis = Union[int, Tuple[int, ...]]
 
 class CorrValue(NamedTuple):
-    ccc: np.ndarray
-    rho: np.ndarray
+    concor: np.ndarray
+    pearson: np.ndarray
 
 
 def read_yml_file(yml_filepath):
@@ -170,17 +170,15 @@ def batch_correlate(
     y_std = np.sqrt(y_var)
     y_norm = (y - y_mean) / y_std
 
-    # Pearson correlation
-    rho = np.mean(x_norm * y_norm, axis=axis, keepdims=True)
-
-    # Concordance correlation
-    ccc = 2 * rho * x_std * y_std / (x_var + y_var + (x_mean - y_mean) ** 2)
+    # Correlation coefficients
+    pearson = np.mean(x_norm * y_norm, axis=axis, keepdims=True)
+    concor = 2 * pearson * x_std * y_std / (x_var + y_var + (x_mean - y_mean) ** 2)
 
     # Squeeze reduced singleton dimensions
     if axis is not None:
-        ccc = np.squeeze(ccc, axis=axis)
-        rho = np.squeeze(rho, axis=axis)
-    return CorrValue(ccc, rho)
+        concor = np.squeeze(concor, axis=axis)
+        pearson = np.squeeze(pearson, axis=axis)
+    return CorrValue(concor, pearson)
 
 
 def correlate_text_based(txt1, txt2):

--- a/cpac_correlations.py
+++ b/cpac_correlations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from typing import Optional, NamedTuple, Tuple, Union
+
 import os
 import glob
 import numpy as np
@@ -9,6 +11,12 @@ import pandas as pd
 
 from multiprocessing import Pool
 import itertools
+
+Axis = Union[int, Tuple[int, ...]]
+
+class CorrValue(NamedTuple):
+    ccc: np.ndarray
+    rho: np.ndarray
 
 
 def read_yml_file(yml_filepath):
@@ -139,86 +147,51 @@ def parse_csv_data(csv_lines):
     return csv_np_data
 
 
-def concordance(x, y, rho):
+def batch_correlate(
+    x: np.ndarray, y: np.ndarray, axis: Optional[Axis] = None
+) -> CorrValue:
     """
-    Calculates Lin's concordance correlation coefficient.
+    Compute a batch of concordance and Pearson correlation coefficients between
+    x and y along an axis (or axes).
 
-    Usage: concordence(x, y) where x, y are equal-length arrays
-    Returns: concordance correlation coefficient
-
-    Note: strict than pearson
+    References:
+        https://en.wikipedia.org/wiki/Concordance_correlation_coefficient
     """
+    # Summary stats for x
+    x_mean = np.mean(x, axis=axis, keepdims=True)
+    x_var = np.var(x, axis=axis, keepdims=True)
+    x_std = np.sqrt(x_var)
+    # NOTE: Not trying to fix NaNs
+    x_norm = (x - x_mean) / x_std
 
-    import math
-    import numpy as np
+    # Summary stats for y
+    y_mean = np.mean(y, axis=axis, keepdims=True)
+    y_var = np.var(y, axis=axis, keepdims=True)
+    y_std = np.sqrt(y_var)
+    y_norm = (y - y_mean) / y_std
 
-    map(float, x)
-    map(float, y)
-    xvar = np.var(x)
-    yvar = np.var(y)
-    #rho = scipy.stats.pearsonr(x, y)[0]
-    #p = np.corrcoef(x,y)  # numpy version of pearson correlation coefficient
-    ccc = 2. * rho * math.sqrt(xvar) * math.sqrt(yvar) / (xvar + yvar + (np.mean(x) - np.mean(y))**2)
+    # Pearson correlation
+    rho = np.mean(x_norm * y_norm, axis=axis, keepdims=True)
 
-    return ccc
+    # Concordance correlation
+    ccc = 2 * rho * x_std * y_std / (x_var + y_var + (x_mean - y_mean) ** 2)
 
-
-def correlate(data_1, data_2):
-    pearson = scipy.stats.pearsonr(data_1.flatten(), data_2.flatten())[0]
-    concor = concordance(data_1.flatten(), data_2.flatten(), pearson)
-    return (concor, pearson)
-
-
-def quick_corr_csv(csv_1, csv_2):
-    csv_1_lines = read_txt_file(csv_1)
-    csv_2_lines = read_txt_file(csv_2)
-    csv_1_data = parse_csv_data(csv_1_lines)
-    csv_2_data = parse_csv_data(csv_2_lines)
-    if csv_1_data.flatten().shape == csv_2_data.flatten().shape:
-        concor, pearson = correlate(csv_1_data, csv_2_data)
-    print(concor)
-
-
-def correlate_two_nifti_timeseries(ts1_data, ts2_data, shape):
-    ts_pearson = []
-    ts_concordance = []
-    for i in range(0, shape[0]):
-        for j in range(0, shape[1]):
-            for k in range(0, shape[2]):
-                ts_corrs = correlate(ts1_data[i][j][k],
-                                     ts2_data[i][j][k])
-                ts_pearson.append(ts_corrs[1])
-                ts_concordance.append(ts_corrs[0])
-    ts_pearson = np.asarray(ts_pearson)
-    ts_pearson_mean = ts_pearson[~np.isnan(ts_pearson)].mean()
-    ts_concordance = np.asarray(ts_concordance)
-    ts_concordance_mean = ts_concordance[~np.isnan(ts_concordance)].mean()
-    return ts_concordance_mean, ts_pearson_mean
+    # Squeeze reduced singleton dimensions
+    if axis is not None:
+        ccc = np.squeeze(ccc, axis=axis)
+        rho = np.squeeze(rho, axis=axis)
+    return CorrValue(ccc, rho)
 
 
 def correlate_text_based(txt1, txt2):
-    with open(txt1, 'r') as f:
-        lines = f.readlines()
+    # TODO: why do we drop columns containing na?
+    oned_one = pd.read_csv(txt1, delimiter=None, comment="#").dropna(axis=1).values
+    oned_two = pd.read_csv(txt2, delimiter=None, comment="#").dropna(axis=1).values
 
-    line_idx = 0
-    delimiter = ','
-    for line in lines:
-        if '#' in line:
-            line_idx += 1
-        else:
-            if ',' in line:
-                delimiter = ','
-            elif '\t' in line:
-                delimiter = '\t'
-            break
-
-    oned_one = pd.read_csv(txt1, delimiter=delimiter, header=line_idx-1).dropna(axis=1)
-    oned_two = pd.read_csv(txt2, delimiter=delimiter, header=line_idx-1).dropna(axis=1)
-
-    pearson_mean = np.asarray([scipy.stats.pearsonr(oned_one[x], oned_two[x])[0] for x in oned_one.columns]).mean()
-    concor_mean = np.asarray([concordance(oned_one[x], oned_two[x], scipy.stats.pearsonr(oned_one[x], oned_two[x])[0]) for x in oned_one.columns]).mean()
-
-    return (concor_mean, pearson_mean)
+    concor, pearson = batch_correlate(oned_one, oned_two, axis=0)
+    concor = np.nanmean(concor)
+    pearson = np.nanmean(pearson)
+    return concor, pearson
 
 
 def create_unique_file_dict(filepaths, output_folder_path, replacements=None):
@@ -489,8 +462,6 @@ def calculate_correlation(args_tuple):
     import scipy.stats.mstats
     import scipy.stats
     import math
-
-    from cpac_correlations import download_from_s3, concordance
    
     category = args_tuple[0]
     old_path = args_tuple[1]
@@ -603,10 +574,12 @@ def calculate_correlation(args_tuple):
         if data_1.flatten().shape == data_2.flatten().shape:
             try:
                 if len(old_file_dims) > 3:
-                    concor, pearson = correlate_two_nifti_timeseries(data_1, data_2, 
-                                                                     old_file_img.shape)
+                    axis = tuple(range(3, len(old_file_dims)))
+                    concor, pearson = batch_correlate(data_1, data_2, axis=axis)
+                    concor = np.nanmean(concor)
+                    pearson = np.nanmean(pearson)
                 else:
-                    concor, pearson = correlate(data_1, data_2)
+                    concor, pearson = batch_correlate(data_1, data_2)
             except Exception as e:
                 corr_tuple = ("correlating problem: {0}".format(e), 
                               old_path, new_path)
@@ -688,8 +661,6 @@ def run_correlations(matched_dct, input_dct, source='output_dir', quick=False, v
                 args_list.append((category, old_path, new_path, output_dir, s3_creds, verbose))
 
     print("\nNumber of correlations to calculate: {0}\n".format(len(args_list)))
-
-    from cpac_correlations import calculate_correlation
 
     print("Running correlations...")
     p = Pool(input_dct['settings']['n_cpus'])


### PR DESCRIPTION
Based on discussion with @nx10 and @amygutierrez, it seems there might be room to speed up regression testing significantly. This PR makes an initial attempt by vectorizing the computation of Pearson and concordance correlation coefficients.

I checked that the new `batch_correlate()` and old `correlate()` give the same result on random-normal data, up to numerical precision.

I also benchmarked `batch_correlate()` against the old `correlate_two_nifti_timeseries()`:

```python
x = np.random.randn(100, 100, 100, 100)
y = np.random.randn(100, 100, 100, 100)

# 2min 46s ± 1.47 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit correlate_two_nifti_timeseries(x, y, x.shape)

# 4.5 s ± 85.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit batch_correlate(x, y)
```

The speedup is ~36x for data of this size on my laptop.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
