### PR TITLE
👔 Move creation of `correlations.json` to `cpac-correlations` CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   pytest:
     docker:
-      - image: circleci/python:3.7.3
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:

--- a/cpac_correlations/.markdownlint.yaml
+++ b/cpac_correlations/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013: false
+MD024:
+  siblings_only: true

--- a/cpac_correlations/CHANGELOG.md
+++ b/cpac_correlations/CHANGELOG.md
@@ -1,0 +1,35 @@
+<!-- Copyright (C) 2022-2024  C-PAC Developers
+
+This file is part of C-PAC.
+
+C-PAC is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+C-PAC is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with C-PAC. If not, see <https://www.gnu.org/licenses/>. -->
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0]
+
+### Changed
+
+* [Coerce `n_cpus` to int](https://github.com/FCP-INDI/CPAC_regtest_pack/commit/418310362e714157fede0a25cca3f52b2ad609c5)
+* [Make `args` optional](github.com/FCP-INDI/CPAC_regtest_pack/commit/a90cfd41506ce6dca6104868358e46fca9892dad) to facilitate calling as a function or from the CLI
+* Document and update some typehints
+* [Migrate from deprecated CircleCI image](https://circleci.com/docs/next-gen-migration-guide/)
+* Update some style rules to match C-PAC code style
+* Apply the subject-session labels to the correlation coefficients instead of averaging by site
+
+## [1.0.128] - 2023-11-14
+
+### Changed
+
+* Packaged `cpac_correlations`
+
+[1.1.0]: https://github.com/FCP-INDI/CPAC_regtest_pack/releases/tag/cpac_correlations/v1.1.0
+[1.0.128]: https://github.com/FCP-INDI/CPAC_regtest_pack/releases/tag/cpac_correlations/v1.0.128

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -1246,12 +1246,24 @@ class CpacCorrelationsNamespace(argparse.Namespace):
 
     @property
     def cli_args(self) -> list[str]:
-        """Return list of CLI arg strings."""
-        return list(
-            chain.from_iterable(
-                [[f"--{key}", value] for key, value in vars(self).items()]
-            )
-        )
+        """Return list of CLI arg strings.
+
+        >>> CpacCorrelationsNamespace(branch="develop", data_source="HNU_1",
+        ...                           input_yaml="input.yaml").cli_args
+        ['--branch', 'develop', '--data_source', 'HNU_1', 'input.yaml']
+        """
+        return [
+            *list(
+                chain.from_iterable(
+                    [
+                        [f"--{key}", value]
+                        for key, value in vars(self).items()
+                        if key != "input_yaml"
+                    ]
+                )
+            ),
+            self.input_yaml,
+        ]
 
 
 def parse_args() -> CpacCorrelationsNamespace:

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -1171,7 +1171,12 @@ def compare_pipelines(
 
     if correlations_json_path.exists():
         with correlations_json_path.open("r", encoding="utf8") as json_file:
-            correlations_json = [*json.load(json_file), *correlations_json]
+            _loaded_json: list[dict[str, str]] = []
+            try:
+                _loaded_json = json.load(json_file)
+            except json.decoder.JSONDecodeError:
+                pass  # empty or corrupted file
+            correlations_json = [*_loaded_json, *correlations_json]
     with correlations_json_path.open("w", encoding="utf8") as json_file:
         try:
             flock(json_file.fileno(), LOCK_EX)  # Lock the file

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -744,7 +744,7 @@ def run_correlations(
     print("\nNumber of correlations to calculate: {0}\n".format(len(args_list)))
 
     print("Running correlations...")
-    p = Pool(input_dct["settings"]["n_cpus"])
+    p = Pool(int(input_dct["settings"]["n_cpus"]))
     corr_tuple_list = p.map(calculate_correlation, args_list)
     p.close()
     p.join()

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -1106,14 +1106,15 @@ def parse_args() -> CpacCorrelationsNamespace:
     return parser.parse_args(namespace=CpacCorrelationsNamespace())
 
 
-def main(args: CpacCorrelationsNamespace) -> tuple:
+def main(args: Optional[CpacCorrelationsNamespace] = None) -> tuple[list[str], str, str]:
     """Correlate two C-PAC runs.
 
     • Parse commandline arguments
     • Read input YAML
     • Check for already completed stuff (pickles)
     """
-
+    if args is None:
+        args = parse_args()
     data_source: str = args.data_source
     branch: str = args.branch
 
@@ -1152,7 +1153,7 @@ def main(args: CpacCorrelationsNamespace) -> tuple:
 
 
 if __name__ == "__main__":
-    main(parse_args())
+    main()
 
 cpac_correlations = main
 

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+# SBATCH -N 1
+# SBATCH -p RM-shared
+# SBATCH -t 01:00:00
+# SBATCH --ntasks=1
+"""Calculate correlation coefficients for C-PAC outputs."""
 import argparse
 from collections.abc import Generator
 from fcntl import flock, LOCK_EX, LOCK_UN

--- a/cpac_correlations/pyproject.toml
+++ b/cpac_correlations/pyproject.toml
@@ -24,7 +24,7 @@ use_parentheses = true
 dependencies = ["matplotlib", "nibabel", "numpy", "pandas", "pyyaml"]
 name = "cpac_correlations"
 requires-python = ">= 3.9"
-version = "1.0.128"
+version = "1.1.0"
 
 [project.scripts]
 cpac_correlations = "cpac_correlations:main"

--- a/cpac_correlations/pyproject.toml
+++ b/cpac_correlations/pyproject.toml
@@ -3,9 +3,22 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
-order_by_type = "False"
-split_on_trailing_comma = "True"
-use_parentheses = "True"
+combine_as_imports = true
+force_sort_within_sections = true
+known_collab = ["nibabel", "nilearn", "nipype", "PyBASC", "pybids", "scipy", "spython"]
+known_first_party = ["CPAC"]
+known_otherfirstparty = ["flowdump", "indi_aws", "indi_schedulers", "PyPEER"]
+no_lines_before = ["collab", "other-first-party", "local-folder"]
+order_by_type = false
+sections = ["FUTURE",
+ "STDLIB",
+ "THIRDPARTY",
+ "COLLAB",
+ "OTHERFIRSTPARTY",
+ "FIRSTPARTY",
+ "LOCALFOLDER"]
+split_on_trailing_comma = true
+use_parentheses = true
 
 [project]
 dependencies = ["matplotlib", "nibabel", "numpy", "pandas", "pyyaml"]


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to https://github.com/FCP-INDI/C-PAC/issues/1211#issuecomment-2412337228 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Updates `cpac-correlations`/`cpac_correlations` CLI and its underlying functions to generate the files necessary for [childmindresearch/slurm_testing](https://github.com/childmindresearch/slurm_testing) to produce the interactive heatmap and GitHub comment via [FCP-INDI/C-PAC_regression_dashboard](https://github.com/FCP-INDI/C-PAC_regression_dashboard): 
  - `correlations.json`
  - PNG images
  - txt files

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
* Documents and updates some typehints
* [Migrates from deprecated CircleCI image](https://circleci.com/docs/next-gen-migration-guide/)
* Updates some style rules to match C-PAC code style
* Applies the subject-session labels to the correlation coefficients instead of averaging by site
* [Coerces `n_cpus` to int](https://github.com/FCP-INDI/CPAC_regtest_pack/commit/418310362e714157fede0a25cca3f52b2ad609c5)
* [Makes `args` optional](github.com/FCP-INDI/CPAC_regtest_pack/commit/a90cfd41506ce6dca6104868358e46fca9892dad) to facilitate calling as a function or from the CLI
* Adds a CHANGELOG

<details><summary><h2>Screenshot</h2></summary>

[![screenshot of comment](https://github.com/user-attachments/assets/e655a437-f977-4c16-a3e2-09f0f7ad58aa)](https://github.com/shnizzedy/C-PAC/commit/f753ef4fe74cacb829ade505a0110e2a7d4fa3ef#commitcomment-148798919)

</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
