### PR TITLE
👔 Reorient NIfTI images as necessary

### DIFF
--- a/cpac_correlations/CHANGELOG.md
+++ b/cpac_correlations/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+### Added
+
+* Check for orientation and reorientation if necessary for NIfTI images.
+
 ## [1.1.1] - 2025-05-13
 
 ### Fixed

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -32,6 +32,8 @@ import pandas as pd
 import yaml
 
 import nibabel as nb
+from nibabel.orientations import aff2axcodes
+from nibabel.processing import resample_from_to
 
 Axis = Union[int, Tuple[int, ...]]
 
@@ -748,11 +750,9 @@ def calculate_correlation(args_tuple):
             old_img = nb.load(old_path)
             new_img = nb.load(new_path)
 
-            if nb.orientations.aff2axcodes(
-                old_img.affine
-            ) != nb.orientations.aff2axcodes(new_img.affine):
+            if aff2axcodes(old_img.affine) != aff2axcodes(new_img.affine):
                 # reorient old image to new image's orientation
-                old_img = nb.processing.resample_from_to(old_img, new_img)
+                old_img = resample_from_to(old_img, new_img)
 
             data_1 = old_img.get_fdata()
             data_2 = new_img.get_fdata()

--- a/cpac_correlations/cpac_correlations.py
+++ b/cpac_correlations/cpac_correlations.py
@@ -745,8 +745,17 @@ def calculate_correlation(args_tuple):
             old_file_dims = old_file_hdr.get_zooms()
             # new_file_dims = new_file_hdr.get_zooms()
 
-            data_1 = nb.load(old_path).get_fdata()
-            data_2 = nb.load(new_path).get_fdata()
+            old_img = nb.load(old_path)
+            new_img = nb.load(new_path)
+
+            if nb.orientations.aff2axcodes(
+                old_img.affine
+            ) != nb.orientations.aff2axcodes(new_img.affine):
+                # reorient old image to new image's orientation
+                old_img = nb.processing.resample_from_to(old_img, new_img)
+
+            data_1 = old_img.get_fdata()
+            data_2 = new_img.get_fdata()
 
         except Exception as e:
             corr_tuple = (f"file reading problem: {e}", old_path, new_path)

--- a/cpac_correlations/pyproject.toml
+++ b/cpac_correlations/pyproject.toml
@@ -24,7 +24,7 @@ use_parentheses = true
 dependencies = ["matplotlib", "nibabel", "numpy", "pandas", "pyyaml"]
 name = "cpac_correlations"
 requires-python = ">= 3.9"
-version = "1.1.1"
+version = "1.1.2"
 
 [project.scripts]
 cpac_correlations = "cpac_correlations:main"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

Adds a check for orientation and reorientation if necessary for NIfTI images.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Reorients the "old" image to the "new" images orientation if the orientations differ.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

<img width="1175" height="1467" alt="screenshot of a Jupyter notebook showing successful reoriented correlations" src="https://github.com/user-attachments/assets/cfea37c1-d679-413a-a267-c9bc188bcb49" />

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
